### PR TITLE
Support random UIDs

### DIFF
--- a/9.2/Dockerfile
+++ b/9.2/Dockerfile
@@ -24,13 +24,16 @@ EXPOSE 5432
 # to make sure of that.
 RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
     yum -y --setopt=tsflags=nodocs install https://www.softwarecollections.org/en/scls/rhscl/postgresql92/epel-7-x86_64/download/rhscl-postgresql92-epel-7-x86_64.noarch.rpm && \
-    yum -y --setopt=tsflags=nodocs install gettext postgresql92 && \
+    yum -y --setopt=tsflags=nodocs --enablerepo=centosplus install gettext postgresql92 epel-release && \
+    yum -y --setopt=tsflags=nodocs install nss_wrapper && \
     yum clean all && \
     mkdir -p /var/lib/pgsql/data && chown postgres.postgres /var/lib/pgsql/data && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)"
 
 COPY run-postgresql.sh /usr/local/bin/
 COPY contrib /var/lib/pgsql/
+
+RUN chmod -R go+rwx /var/lib/pgsql && chmod go+w /var/run/postgresql
 
 VOLUME ["/var/lib/pgsql/data"]
 

--- a/9.2/Dockerfile.rhel7
+++ b/9.2/Dockerfile.rhel7
@@ -26,12 +26,17 @@ RUN yum install -y yum-utils gettext && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum install -y --setopt=tsflags=nodocs postgresql92 && \
+    curl -O https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm && \
+    rpm -Uvh epel-release-7-5.noarch.rpm && rm epel-release-7-5.noarch.rpm && \
+    yum install -y --enablerepo=epel --setopt=tsflags=nodocs nss_wrapper && \
     yum clean all && \
     mkdir -p /var/lib/pgsql/data && chown postgres.postgres /var/lib/pgsql/data && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)"
 
 COPY run-postgresql.sh /usr/local/bin/
 COPY contrib /var/lib/pgsql/
+
+RUN chmod -R go+rwx /var/lib/pgsql && chmod go+w /var/run/postgresql
 
 VOLUME ["/var/lib/pgsql/data"]
 

--- a/9.2/contrib/passwd.template
+++ b/9.2/contrib/passwd.template
@@ -1,0 +1,14 @@
+root:x:0:0:root:/root:/bin/bash
+bin:x:1:1:bin:/bin:/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/sbin/nologin
+adm:x:3:4:adm:/var/adm:/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+sync:x:5:0:sync:/sbin:/bin/sync
+shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+halt:x:7:0:halt:/sbin:/sbin/halt
+mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
+operator:x:11:0:operator:/root:/sbin/nologin
+games:x:12:100:games:/usr/games:/sbin/nologin
+ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
+nobody:x:99:99:Nobody:/:/sbin/nologin
+postgres:x:${USER_ID}:26:PostgreSQL Server:/var/lib/pgsql:/bin/bash

--- a/9.2/test/run
+++ b/9.2/test/run
@@ -79,9 +79,10 @@ function test_postgresql() {
 
 function create_container() {
 	local name=$1 ; shift
+	local cargs=${CONTAINER_ARGS:-}
 	cidfile="$CIDFILE_DIR/$name"
 	# create container with a cidfile in a directory for cleanup
-	docker run --cidfile $cidfile -d "$@" $IMAGE_NAME
+	docker run $cargs --cidfile $cidfile -d "$@" $IMAGE_NAME
 	echo "Created container $(cat $cidfile)"
 }
 
@@ -184,3 +185,6 @@ run_container_creation_tests
 run_configuration_tests
 USER=user PASS=pass run_tests no_admin
 USER=user1 PASS=pass1 ADMIN_PASS=r00t run_tests admin
+# Test with arbitrary uid for the container
+CONTAINER_ARGS="-u 12345" USER=user2 PASS=pass run_tests no_admin_altuid
+CONTAINER_ARGS="-u 12345" USER=user3 PASS=pass1 ADMIN_PASS=r00t run_tests admin_altuid


### PR DESCRIPTION
This PR allows the postgresql image to start with a random uid as in:
```
docker run -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass \
   -e POSTGRESQL_DATABASE=db -p 5432:5432 \
   -u 12345 openshift/postgresql-92-centos7
```
It requires the use of a nss provider because postgresql tries to look up the current username with the uid. By passing in a dynamically generated passwd file to nss_wrapper.so, it's possible to make postgresql think that the current user's name is 'postgres'. Currently nss_wrapper.so is included in the PR but ideally it'd be downloaded from the SCL server. There's a fedora package for it here: https://apps.fedoraproject.org/packages/nss_wrapper