### PR TITLE
Support for XA transactions

### DIFF
--- a/9.2/contrib/openshift-custom-postgresql.conf.template
+++ b/9.2/contrib/openshift-custom-postgresql.conf.template
@@ -13,3 +13,6 @@ max_connections = ${POSTGRESQL_MAX_CONNECTIONS}
 
 # Sets the amount of memory the database server uses for shared memory buffers. Default: 32MB
 shared_buffers = ${POSTGRESQL_SHARED_BUFFERS}
+
+# Sets the maximum number of transactions that can be in the "prepared" state simultaneously - XA support. Default: 0 (disabled)
+max_prepared_transactions = ${POSTGRESQL_MAX_PREPARED_TXS}

--- a/9.2/run-postgresql.sh
+++ b/9.2/run-postgresql.sh
@@ -22,6 +22,7 @@ POSTGRESQL_CONFIG_FILE=$HOME/openshift-custom-postgresql.conf
 # Configuration settings.
 export POSTGRESQL_MAX_CONNECTIONS=${POSTGRESQL_MAX_CONNECTIONS:-100}
 export POSTGRESQL_SHARED_BUFFERS=${POSTGRESQL_SHARED_BUFFERS:-32MB}
+export POSTGRESQL_MAX_PREPARED_TXS=${POSTGRESQL_MAX_PREPARED_TXS:-0}
 
 # Be paranoid and stricter than we should be.
 psql_identifier_regex='^[a-zA-Z_][a-zA-Z0-9_]*$'
@@ -40,6 +41,7 @@ function usage() {
 	echo "Settings:"
 	echo "  POSTGRESQL_MAX_CONNECTIONS (default: 100)"
 	echo "  POSTGRESQL_SHARED_BUFFERS (default: 32MB)"
+	echo "  POSTGRESQL_MAX_PREPARED_TXS (default: 0)"
 	exit 1
 }
 

--- a/9.2/test/run
+++ b/9.2/test/run
@@ -153,6 +153,7 @@ function run_configuration_tests() {
 	echo "  Testing image configuration settings"
 	test_config_option POSTGRESQL_MAX_CONNECTIONS max_connections 42
 	test_config_option POSTGRESQL_SHARED_BUFFERS shared_buffers 64MB
+	test_config_option POSTGRESQL_MAX_PREPARED_TXS max_prepared_transactions 10
 	echo "  Success!"
 }
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Following environment variables influence PostgreSQL configuration file. They ar
 | :---------------------------- | ----------------------------------------------------------------------- | -------------------------------
 |  `POSTGRESQL_MAX_CONNECTIONS` | The maximum number of client connections allowed                        |  100
 |  `POSTGRESQL_SHARED_BUFFERS`  | Sets how much memory is dedicated to PostgreSQL to use for caching data |  32M
+|  `POSTGRESQL_MAX_PREPARED_TXS | Sets the maximum number of simultaneous "prepared" transactions - XA support. |  0 (XA disabled)
 
 You can also set following mount points by passing `-v /host:/container` flag to docker.
 


### PR DESCRIPTION
Middleware images frequently needs database that s able to participate in XA transaction. For PostgreSQL this is achieved by setting max_prepared_transactions configuration setting to non-zero value. This PR provides MAX_PREPARED_TXS configration variable that allows dpeloyer to enable XA for the image.