### PR TITLE
Generate locale archive

### DIFF
--- a/9.2/Dockerfile
+++ b/9.2/Dockerfile
@@ -33,6 +33,7 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
     yum -y --setopt=tsflags=nodocs --enablerepo=centosplus install gettext bind-utils postgresql92 epel-release && \
     yum -y --setopt=tsflags=nodocs install nss_wrapper && \
     yum clean all && \
+    localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     mkdir -p /var/lib/pgsql/data && chown postgres.postgres /var/lib/pgsql/data && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \
     chmod -R go+rwx /var/lib/pgsql && chmod go+w /var/run/postgresql

--- a/9.2/Dockerfile.rhel7
+++ b/9.2/Dockerfile.rhel7
@@ -45,6 +45,7 @@ RUN yum install -y yum-utils gettext && \
     yum install -y --setopt=tsflags=nodocs bind-utils postgresql92 && \
     yum install -y --disablerepo="epel" --setopt=tsflags=nodocs nss_wrapper && \
     yum clean all && \
+    localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     mkdir -p /var/lib/pgsql/data && chown postgres.postgres /var/lib/pgsql/data && \
     test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \
     chmod -R go+rwx /var/lib/pgsql && chmod go+w /var/run/postgresql


### PR DESCRIPTION
Recent RHEL7 image doesn't include the locale archive. Generate it
during Docker build. This does not affect the CentOS image, however,
generate it there as well just to be safe for the future.

Fixes RH bug 1245444.