### PR TITLE
Refactor assert_login_access

### DIFF
--- a/9.2/test/run
+++ b/9.2/test/run
@@ -90,26 +90,20 @@ function assert_login_access() {
   local USER=$1 ; shift
   local PASS=$1 ; shift
   local success=$1 ; shift
-  (
-    set +e
-    postgresql_cmd <<< "SELECT 1;"
-    status=$?
 
-    if $success; then
-      if [ $status -eq 0 ]; then
-        echo "    $USER($PASS) access granted as expected"
-        exit 0
-      fi
-    else
-      if [ $status -ne 0 ]; then
-        echo "    $USER($PASS) access denied as expected"
-        exit 0
-      fi
+  if postgresql_cmd <<<'SELECT 1;' ; then
+    if $success ; then
+      echo "    $USER($PASS) access granted as expected"
+      return
     fi
-    echo "    $USER($PASS) login assertion failed"
-    exit 1
-  )
-  test $?
+  else
+    if ! $success ; then
+      echo "    $USER($PASS) access denied as expected"
+      return
+    fi
+  fi
+  echo "    $USER($PASS) login assertion failed"
+  exit 1
 }
 
 function assert_local_access() {


### PR DESCRIPTION
No need to run in a subshell nor to use `set +e`.

Follows up #53 


@bparees @mfojtik PTAL