### PR TITLE
Fix random user test (was: Remove NSSWRAPPER code)

### DIFF
--- a/9.2/test/run
+++ b/9.2/test/run
@@ -198,7 +198,7 @@ function run_tests() {
   if [ -v ADMIN_PASS ]; then
     envs="$envs -e POSTGRESQL_ADMIN_PASSWORD=$ADMIN_PASS"
   fi
-  DOCKER_ARGS="$envs" create_container $name
+  DOCKER_ARGS="${DOCKER_ARGS:-} $envs" create_container $name
   CONTAINER_IP=$(get_container_ip $name)
   test_connection $name
   echo "  Testing scl usage"


### PR DESCRIPTION
Seems that this is not needed (anymore?) to have PostgreSQL working with random UIDs.
(We have a test that runs docker with UID 12345)

@csrwng @bparees PTAL