### PR TITLE
Setting groupID via env var

### DIFF
--- a/9.2/contrib/common.sh
+++ b/9.2/contrib/common.sh
@@ -69,6 +69,7 @@ function generate_postgresql_config() {
 # Generate passwd file based on current uid
 function generate_passwd_file() {
   export USER_ID=$(id -u)
+  export GROUP_ID=$(id -g)
   envsubst < ${HOME}/passwd.template > ${HOME}/passwd
   export LD_PRELOAD=libnss_wrapper.so
   export NSS_WRAPPER_PASSWD=/var/lib/pgsql/passwd

--- a/9.2/contrib/passwd.template
+++ b/9.2/contrib/passwd.template
@@ -11,4 +11,4 @@ operator:x:11:0:operator:/root:/sbin/nologin
 games:x:12:100:games:/usr/games:/sbin/nologin
 ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
 nobody:x:99:99:Nobody:/:/sbin/nologin
-postgres:x:${USER_ID}:26:PostgreSQL Server:/var/lib/pgsql:/bin/bash
+postgres:x:${USER_ID}:${GROUP_ID}:PostgreSQL Server:${HOME}:/bin/bash


### PR DESCRIPTION
@mfojtik PTAL
Also I looked into other images and I like the *_HOME (eg. JENKINS_HOME) vars that we are using. But I guess that just needed for Jenkins. Or ?   