### PR TITLE
Remove MAINTAINER in RHEL image

### DIFF
--- a/9.2/Dockerfile.rhel7
+++ b/9.2/Dockerfile.rhel7
@@ -10,8 +10,6 @@ FROM rhel7
 #  * $POSTGRESQL_ADMIN_PASSWORD (Optional) - Password for the 'postgres'
 #                           PostgreSQL administrative account
 
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 ENV POSTGRESQL_VERSION=9.2 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres

--- a/9.4/Dockerfile.rhel7
+++ b/9.4/Dockerfile.rhel7
@@ -10,8 +10,6 @@ FROM rhel7
 #  * $POSTGRESQL_ADMIN_PASSWORD (Optional) - Password for the 'postgres'
 #                           PostgreSQL administrative account
 
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 ENV POSTGRESQL_VERSION=9.4 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres


### PR DESCRIPTION
We don't what to use MAINTAINER in RHEL images.