### PR TITLE
sync build-scripts with other images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,7 @@
-SKIP_SQUASH?=0
-VERSIONS="9.2 9.4"
+# Variables are documented in hack/build.sh.
+BASE_IMAGE_NAME = postgresql
+VERSIONS = 9.2 9.4
+OPENSHIFT_NAMESPACES = 9.2
 
-ifeq ($(TARGET),rhel7)
-	OS := rhel7
-else
-	OS := centos7
-endif
-
-ifeq ($(VERSION), 9.2)
-	VERSION := 9.2
-else ifeq ($(VERSION), 9.4)
-	VERSION := 9.4
-else
-	VERSION :=
-endif
-
-.PHONY: build
-build:
-	SKIP_SQUASH=$(SKIP_SQUASH) VERSIONS=$(VERSIONS) hack/build.sh $(OS) $(VERSION)
-
-.PHONY: test
-test:
-	SKIP_SQUASH=$(SKIP_SQUASH) VERSIONS=$(VERSIONS) TAG_ON_SUCCESS=$(TAG_ON_SUCCESS) TEST_MODE=true hack/build.sh $(OS) $(VERSION)
+# Include common Makefile code.
+include hack/common.mk

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,19 +1,28 @@
 #!/bin/bash -e
 # This script is used to build, test and squash the OpenShift Docker images.
 #
-# $1 - Specifies distribution - "rhel7" or "centos7"
-# $2 - Specifies the image version - (must match with subdirectory in repo)
+# Name of resulting image will be: 'NAMESPACE/BASE_IMAGE_NAME-VERSION-OS'.
+#
+# BASE_IMAGE_NAME - Usually name of the main component within container.
+# OS - Specifies distribution - "rhel7" or "centos7"
+# VERSION - Specifies the image version - (must match with subdirectory in repo)
 # TEST_MODE - If set, build a candidate image and test it
 # TAG_ON_SUCCESS - If set, tested image will be re-tagged as a non-candidate
-#                  image, if the tests pass.
+#       image, if the tests pass.
 # VERSIONS - Must be set to a list with possible versions (subdirectories)
+# OPENSHIFT_NAMESPACES - Which of available versions (subdirectories) should be
+#       put into openshift/ namespace.
 
-OS=$1
-VERSION=$2
+OS=${1-$OS}
+VERSION=${2-$VERSION}
 
 DOCKERFILE_PATH=""
-BASE_DIR_NAME=$(echo $(basename `pwd`) | sed -e 's/-[0-9]*$//g')
-BASE_IMAGE_NAME="${BASE_DIR_NAME#sti-}"
+
+test -z "$BASE_IMAGE_NAME" && {
+  BASE_DIR_NAME=$(echo $(basename `pwd`) | sed -e 's/-[0-9]*$//g')
+  BASE_IMAGE_NAME="${BASE_DIR_NAME#sti-}"
+}
+
 NAMESPACE="openshift/"
 
 # Cleanup the temporary Dockerfile created by docker build with version
@@ -49,13 +58,16 @@ function squash {
 dirs=${VERSION:-$VERSIONS}
 
 for dir in ${dirs}; do
-  if [ "$dir" == "9.4" ]; then
-    if [ "${OS}" == "centos7" ]; then
-      NAMESPACE="centos/"
-    else
-      NAMESPACE="rhscl/"
-    fi
-  fi
+  case " $OPENSHIFT_NAMESPACES " in
+    *\ ${dir}\ *) ;;
+    *)
+      if [ "${OS}" == "centos7" ]; then
+        NAMESPACE="centos/"
+      else
+        NAMESPACE="rhscl/"
+      fi
+  esac
+
   IMAGE_NAME="${NAMESPACE}${BASE_IMAGE_NAME}-${dir//./}-${OS}"
 
   if [[ -v TEST_MODE ]]; then

--- a/hack/common.mk
+++ b/hack/common.mk
@@ -1,0 +1,25 @@
+SKIP_SQUASH?=0
+
+build = hack/build.sh
+
+ifeq ($(TARGET),rhel7)
+	OS := rhel7
+else
+	OS := centos7
+endif
+
+script_env = \
+	SKIP_SQUASH=$(SKIP_SQUASH)                      \
+	VERSIONS="$(VERSIONS)"                          \
+	OS=$(OS)                                        \
+	VERSION=$(VERSION)                              \
+	BASE_IMAGE_NAME=$(BASE_IMAGE_NAME)              \
+	OPENSHIFT_NAMESPACES="$(OPENSHIFT_NAMESPACES)"
+
+.PHONY: build
+build:
+	$(script_env) $(build)
+
+.PHONY: test
+test:
+	$(script_env) TAG_ON_SUCCESS=$(TAG_ON_SUCCESS) TEST_MODE=true $(build)


### PR DESCRIPTION
- hack/ directory should be _just_ mirrored
- Makefile should be as declarative as possible
- build.sh should not rely on repository name