### PR TITLE
Use explicit rhel7 version

### DIFF
--- a/9.2/Dockerfile.rhel7
+++ b/9.2/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM rhel7
+FROM rhel7.1
 
 # PostgreSQL image for OpenShift.
 # Volumes:

--- a/9.4/Dockerfile.rhel7
+++ b/9.4/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM rhel7
+FROM rhel7.1
 
 # PostgreSQL image for OpenShift.
 # Volumes:


### PR DESCRIPTION
Using `rhel7` only doesn't have to correspond with what we expect (latest rhel7), so we need to be more explicit here.