### PR TITLE
Remove slave data before starting

### DIFF
--- a/9.2/root/usr/bin/run-postgresql-slave
+++ b/9.2/root/usr/bin/run-postgresql-slave
@@ -8,7 +8,8 @@ set_pgdata
 
 function initialize_replica() {
   echo "Initializing PostgreSQL slave ..."
-  chmod 0700 $PGDATA
+  # TODO: Validate and reuse existing data?
+  rm -rf $PGDATA
   PGPASSWORD="${POSTGRESQL_MASTER_PASSWORD}" pg_basebackup -x --no-password --pgdata ${PGDATA} --host=${MASTER_FQDN} --port=5432 -U "${POSTGRESQL_MASTER_USER}"
 
   # PostgreSQL recovery configuration.

--- a/9.4/root/usr/bin/run-postgresql-slave
+++ b/9.4/root/usr/bin/run-postgresql-slave
@@ -8,7 +8,8 @@ set_pgdata
 
 function initialize_replica() {
   echo "Initializing PostgreSQL slave ..."
-  chmod 0700 $PGDATA
+  # TODO: Validate and reuse existing data?
+  rm -rf $PGDATA
   PGPASSWORD="${POSTGRESQL_MASTER_PASSWORD}" pg_basebackup -x --no-password --pgdata ${PGDATA} --host=${MASTER_FQDN} --port=5432 -U "${POSTGRESQL_MASTER_USER}"
 
   # PostgreSQL recovery configuration.


### PR DESCRIPTION
This is required for us, because when an OpenShift pod gets restarted, sometimes
it gets the data volume, with old data. It would be nice to not delete it every
time, but no time to get fancy right now.