### PR TITLE
Add a PostgreSQL version parameter to the replica template

### DIFF
--- a/examples/replica/postgresql_replica.json
+++ b/examples/replica/postgresql_replica.json
@@ -62,6 +62,12 @@
       "required": true
     },
     {
+      "name": "POSTGRESQL_IMAGE",
+      "description": "PostgreSQL Docker image to use",
+      "value": "openshift/postgresql-92-centos7",
+      "required": true
+    },
+    {
       "name": "VOLUME_CAPACITY",
       "description": "Volume space available for data, e.g. 512Mi, 2Gi",
       "value": "512Mi",
@@ -167,7 +173,7 @@
             "containers": [
               {
                 "name": "postgresql-master",
-                "image": "openshift/postgresql-92-centos7",
+                "image": "${POSTGRESQL_IMAGE}",
                 "args": [
                   "run-postgresql-master"
                 ],
@@ -249,7 +255,7 @@
             "containers": [
               {
                 "name": "postgresql-slave",
-                "image": "openshift/postgresql-92-centos7",
+                "image": "${POSTGRESQL_IMAGE}",
                 "args": [
                   "run-postgresql-slave"
                 ],


### PR DESCRIPTION
Since we only have one version of the PostgreSQL template and I want to be able to test both our versions in my tests, I decided to introduce a POSTGRESQL_VERSION template parameter to be able to specify it. I think it is better in that it saves us the duplication. I think it is worse in that we do not use such a parameter anywhere else. And we do not have any parameter validation, so if user puts in something else than 92 or 94, he will have weird errors.

Maybe we should have the whole image as a parameter? Comments welcome.