### PR TITLE
Fix usage error output

### DIFF
--- a/9.2/root/usr/share/container-scripts/postgresql/common.sh
+++ b/9.2/root/usr/share/container-scripts/postgresql/common.sh
@@ -11,7 +11,7 @@ psql_identifier_regex='^[a-zA-Z_][a-zA-Z0-9_]*$'
 psql_password_regex='^[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]+$'
 
 function usage() {
-  if [ $# == 2 ]; then
+  if [ $# == 1 ]; then
     echo >&2 "error: $1"
   fi
   echo >&2 "You must either specify the following environment variables:"

--- a/9.4/root/usr/share/container-scripts/postgresql/common.sh
+++ b/9.4/root/usr/share/container-scripts/postgresql/common.sh
@@ -11,7 +11,7 @@ psql_identifier_regex='^[a-zA-Z_][a-zA-Z0-9_]*$'
 psql_password_regex='^[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]+$'
 
 function usage() {
-  if [ $# == 2 ]; then
+  if [ $# == 1 ]; then
     echo >&2 "error: $1"
   fi
   echo >&2 "You must either specify the following environment variables:"


### PR DESCRIPTION
The usage error was not printed out because we were checking for wrong
number of arguments.