### PR TITLE
Ensuring PGDATA sane permissions

### DIFF
--- a/9.2/root/usr/share/container-scripts/postgresql/common.sh
+++ b/9.2/root/usr/share/container-scripts/postgresql/common.sh
@@ -183,6 +183,8 @@ function set_pgdata ()
     mkdir -p "${HOME}/data/userdata"
   fi
   export PGDATA=$HOME/data/userdata
+  # ensure sane perms for postgresql startup
+  chmod 700 "$PGDATA"
 }
 
 function wait_for_postgresql_master() {

--- a/9.4/root/usr/share/container-scripts/postgresql/common.sh
+++ b/9.4/root/usr/share/container-scripts/postgresql/common.sh
@@ -183,6 +183,8 @@ function set_pgdata ()
     mkdir -p "${HOME}/data/userdata"
   fi
   export PGDATA=$HOME/data/userdata
+  # ensure sane perms for postgresql startup
+  chmod 700 "$PGDATA"
 }
 
 function wait_for_postgresql_master() {


### PR DESCRIPTION
Looks like [this](https://github.com/kubernetes/kubernetes/blob/dff7490c57f309e8ba29563a35d9e2147f241f9a/pkg/volume/volume_linux.go#L74) is something postgres [doesn't like much](https://github.com/postgres/postgres/blob/REL9_4_STABLE/src/backend/postmaster/postmaster.c#L1462-L1467).