### PR TITLE
Tune shared_buffers and effective_cache_size based on given memory

### DIFF
--- a/9.2/README.md
+++ b/9.2/README.md
@@ -24,6 +24,7 @@ The following environment variables influence the PostgreSQL configuration file.
 | :---------------------------- | ----------------------------------------------------------------------- | -------------------------------
 |  `POSTGRESQL_MAX_CONNECTIONS` | The maximum number of client connections allowed. This also sets the maximum number of prepared transactions. |  100
 |  `POSTGRESQL_SHARED_BUFFERS`  | Sets how much memory is dedicated to PostgreSQL to use for caching data |  32M
+|  `POSTGRESQL_EFFECTIVE_CACHE_SIZE`  | Set to an estimate of how much memory is available for disk caching by the operating system and within the database itself |  128M
 
 You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
 
@@ -59,6 +60,18 @@ or if it was already present, [`postgres`](http://www.postgresql.org/docs/9.2/st
 is executed and will run as PID 1. You can stop the detached container by running
 `docker stop postgresql_database`.
 
+PostgreSQL auto-tuning
+--------------------
+
+When the PostgreSQL image is run with the `--memory` parameter set and if there
+are no values provided for `POSTGRESQL_SHARED_BUFFERS` and
+`POSTGRESQL_EFFECTIVE_CACHE_SIZE` those values are automatically calculated
+based on the value provided in the `--memory` parameter.
+
+The values are calculated based on the
+[upstream](https://wiki.postgresql.org/wiki/Tuning_Your_PostgreSQL_Server)
+formulas. For the `shared_buffers` we use 1/4 of given memory and for the
+`effective_cache_size` we set the value to 1/2 of the given memory.
 
 PostgreSQL admin account
 ------------------------

--- a/9.2/root/usr/bin/cgroup-limits
+++ b/9.2/root/usr/bin/cgroup-limits
@@ -1,0 +1,92 @@
+#!/usr/bin/python
+
+"""
+Script for parsing cgroup information
+
+This script will read some limits from the cgroup system and parse
+them, printing out "VARIABLE=VALUE" on each line for every limit that is
+successfully read. Output of this script can be directly fed into
+bash's export command. Recommended usage from a bash script:
+
+    set -o errexit
+    export_vars=$(cgroup-limits) ; export $export_vars
+
+Variables currently supported:
+    MAX_MEMORY_LIMIT_IN_BYTES
+        Maximum possible limit MEMORY_LIMIT_IN_BYTES can have. This is
+        currently constant value of 9223372036854775807.
+    MEMORY_LIMIT_IN_BYTES
+        Maximum amount of user memory in bytes. If this value is set
+        to the same value as MAX_MEMORY_LIMIT_IN_BYTES, it means that
+        there is no limit set. The value is taken from
+        /sys/fs/cgroup/memory/memory.limit_in_bytes
+    NUMBER_OF_CORES
+        Number of detected CPU cores that can be used. This value is
+        calculated from /sys/fs/cgroup/cpuset/cpuset.cpus
+    NO_MEMORY_LIMIT
+        Set to "true" if MEMORY_LIMIT_IN_BYTES is so high that the caller
+        can act as if no memory limit was set. Undefined otherwise.
+"""
+
+from __future__ import print_function
+import sys
+
+
+def _read_file(path):
+    try:
+        with open(path, 'r') as f:
+            return f.read().strip()
+    except IOError:
+        return None
+
+
+def get_memory_limit():
+    """
+    Read memory limit, in bytes.
+    """
+
+    limit = _read_file('/sys/fs/cgroup/memory/memory.limit_in_bytes')
+    if limit is None or not limit.isdigit():
+        print("Warning: Can't detect memory limit from cgroups",
+              file=sys.stderr)
+        return None
+    return int(limit)
+
+
+def get_number_of_cores():
+    """
+    Read number of CPU cores.
+    """
+
+    core_count = 0
+
+    line = _read_file('/sys/fs/cgroup/cpuset/cpuset.cpus')
+    if line is None:
+        print("Warning: Can't detect number of CPU cores from cgroups",
+              file=sys.stderr)
+        return None
+
+    for group in line.split(','):
+        core_ids = list(map(int, group.split('-')))
+        if len(core_ids) == 2:
+            core_count += core_ids[1] - core_ids[0] + 1
+        else:
+            core_count += 1
+
+    return core_count
+
+
+if __name__ == "__main__":
+    env_vars = {
+        "MAX_MEMORY_LIMIT_IN_BYTES": 9223372036854775807,
+        "MEMORY_LIMIT_IN_BYTES": get_memory_limit(),
+        "NUMBER_OF_CORES": get_number_of_cores()
+    }
+
+    env_vars = {k: v for k, v in env_vars.items() if v is not None}
+
+    if env_vars.get("MEMORY_LIMIT_IN_BYTES", 0) >= 92233720368547:
+        env_vars["NO_MEMORY_LIMIT"] = "true"
+
+    for key, value in env_vars.items():
+        print("{0}={1}".format(key, value))

--- a/9.2/root/usr/bin/run-postgresql
+++ b/9.2/root/usr/bin/run-postgresql
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -eu
+export_vars=$(cgroup-limits) ; export $export_vars
 
 source "${CONTAINER_SCRIPTS_PATH}/common.sh"
 

--- a/9.2/root/usr/share/container-scripts/postgresql/common.sh
+++ b/9.2/root/usr/share/container-scripts/postgresql/common.sh
@@ -1,6 +1,22 @@
 # Configuration settings.
 export POSTGRESQL_MAX_CONNECTIONS=${POSTGRESQL_MAX_CONNECTIONS:-100}
-export POSTGRESQL_SHARED_BUFFERS=${POSTGRESQL_SHARED_BUFFERS:-32MB}
+
+# Perform auto-tuning based on the container cgroups limits (only when the
+# limits are set).
+# Users can still override this by setting the POSTGRESQL_SHARED_BUFFERS
+# and POSTGRESQL_EFFECTIVE_CACHE_SIZE variables.
+if [[ "${NO_MEMORY_LIMIT}" == "true" ]]; then
+    export POSTGRESQL_SHARED_BUFFERS=${POSTGRESQL_SHARED_BUFFERS:-32MB}
+    export POSTGRESQL_EFFECTIVE_CACHE_SIZE=${POSTGRESQL_EFFECTIVE_CACHE_SIZE:-128MB}
+else
+    # Use 1/4 of given memory for shared buffers
+    shared_buffers_computed="$(($MEMORY_LIMIT_IN_BYTES/1024/1024/4))M"
+    # Setting effective_cache_size to 1/2 of total memory would be a normal conservative setting,
+    effective_cache="$(($MEMORY_LIMIT_IN_BYTES/1024/1024/2))M"
+    export POSTGRESQL_SHARED_BUFFERS=${POSTGRESQL_SHARED_BUFFERS:-$shared_buffers_computed}
+    export POSTGRESQL_EFFECTIVE_CACHE_SIZE=${POSTGRESQL_EFFECTIVE_CACHE_SIZE:-$effective_cache}
+
+fi
 
 export POSTGRESQL_RECOVERY_FILE=$HOME/openshift-custom-recovery.conf
 export POSTGRESQL_CONFIG_FILE=$HOME/openshift-custom-postgresql.conf

--- a/9.2/root/usr/share/container-scripts/postgresql/openshift-custom-postgresql.conf.template
+++ b/9.2/root/usr/share/container-scripts/postgresql/openshift-custom-postgresql.conf.template
@@ -17,6 +17,9 @@ max_prepared_transactions = ${POSTGRESQL_MAX_CONNECTIONS}
 # Sets the amount of memory the database server uses for shared memory buffers. Default: 32MB
 shared_buffers = ${POSTGRESQL_SHARED_BUFFERS}
 
+# Sets the planner's assumption about the effective size of the disk cache that is available to a single query
+effective_cache_size = ${POSTGRESQL_EFFECTIVE_CACHE_SIZE}
+
 # required on master for replication
 wal_level = hot_standby         # minimal, archive, hot_standby, or logical
 max_wal_senders = 6             # max number of walsender processes

--- a/9.4/README.md
+++ b/9.4/README.md
@@ -24,6 +24,7 @@ The following environment variables influence the PostgreSQL configuration file.
 | :---------------------------- | ----------------------------------------------------------------------- | -------------------------------
 |  `POSTGRESQL_MAX_CONNECTIONS` | The maximum number of client connections allowed. This also sets the maximum number of prepared transactions. |  100
 |  `POSTGRESQL_SHARED_BUFFERS`  | Sets how much memory is dedicated to PostgreSQL to use for caching data |  32M
+|  `POSTGRESQL_EFFECTIVE_CACHE_SIZE`  | Set to an estimate of how much memory is available for disk caching by the operating system and within the database itself |  128M
 
 You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
 
@@ -59,6 +60,18 @@ or if it was already present, [`postgres`](http://www.postgresql.org/docs/9.4/st
 is executed and will run as PID 1. You can stop the detached container by running
 `docker stop postgresql_database`.
 
+PostgreSQL auto-tuning
+--------------------
+
+When the PostgreSQL image is run with the `--memory` parameter set and if there
+are no values provided for `POSTGRESQL_SHARED_BUFFERS` and
+`POSTGRESQL_EFFECTIVE_CACHE_SIZE` those values are automatically calculated
+based on the value provided in the `--memory` parameter.
+
+The values are calculated based on the
+[upstream](https://wiki.postgresql.org/wiki/Tuning_Your_PostgreSQL_Server)
+formulas. For the `shared_buffers` we use 1/4 of given memory and for the
+`effective_cache_size` we set the value to 1/2 of the given memory.
 
 PostgreSQL admin account
 ------------------------

--- a/9.4/root/usr/bin/cgroup-limits
+++ b/9.4/root/usr/bin/cgroup-limits
@@ -1,0 +1,92 @@
+#!/usr/bin/python
+
+"""
+Script for parsing cgroup information
+
+This script will read some limits from the cgroup system and parse
+them, printing out "VARIABLE=VALUE" on each line for every limit that is
+successfully read. Output of this script can be directly fed into
+bash's export command. Recommended usage from a bash script:
+
+    set -o errexit
+    export_vars=$(cgroup-limits) ; export $export_vars
+
+Variables currently supported:
+    MAX_MEMORY_LIMIT_IN_BYTES
+        Maximum possible limit MEMORY_LIMIT_IN_BYTES can have. This is
+        currently constant value of 9223372036854775807.
+    MEMORY_LIMIT_IN_BYTES
+        Maximum amount of user memory in bytes. If this value is set
+        to the same value as MAX_MEMORY_LIMIT_IN_BYTES, it means that
+        there is no limit set. The value is taken from
+        /sys/fs/cgroup/memory/memory.limit_in_bytes
+    NUMBER_OF_CORES
+        Number of detected CPU cores that can be used. This value is
+        calculated from /sys/fs/cgroup/cpuset/cpuset.cpus
+    NO_MEMORY_LIMIT
+        Set to "true" if MEMORY_LIMIT_IN_BYTES is so high that the caller
+        can act as if no memory limit was set. Undefined otherwise.
+"""
+
+from __future__ import print_function
+import sys
+
+
+def _read_file(path):
+    try:
+        with open(path, 'r') as f:
+            return f.read().strip()
+    except IOError:
+        return None
+
+
+def get_memory_limit():
+    """
+    Read memory limit, in bytes.
+    """
+
+    limit = _read_file('/sys/fs/cgroup/memory/memory.limit_in_bytes')
+    if limit is None or not limit.isdigit():
+        print("Warning: Can't detect memory limit from cgroups",
+              file=sys.stderr)
+        return None
+    return int(limit)
+
+
+def get_number_of_cores():
+    """
+    Read number of CPU cores.
+    """
+
+    core_count = 0
+
+    line = _read_file('/sys/fs/cgroup/cpuset/cpuset.cpus')
+    if line is None:
+        print("Warning: Can't detect number of CPU cores from cgroups",
+              file=sys.stderr)
+        return None
+
+    for group in line.split(','):
+        core_ids = list(map(int, group.split('-')))
+        if len(core_ids) == 2:
+            core_count += core_ids[1] - core_ids[0] + 1
+        else:
+            core_count += 1
+
+    return core_count
+
+
+if __name__ == "__main__":
+    env_vars = {
+        "MAX_MEMORY_LIMIT_IN_BYTES": 9223372036854775807,
+        "MEMORY_LIMIT_IN_BYTES": get_memory_limit(),
+        "NUMBER_OF_CORES": get_number_of_cores()
+    }
+
+    env_vars = {k: v for k, v in env_vars.items() if v is not None}
+
+    if env_vars.get("MEMORY_LIMIT_IN_BYTES", 0) >= 92233720368547:
+        env_vars["NO_MEMORY_LIMIT"] = "true"
+
+    for key, value in env_vars.items():
+        print("{0}={1}".format(key, value))

--- a/9.4/root/usr/bin/run-postgresql
+++ b/9.4/root/usr/bin/run-postgresql
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -eu
+export_vars=$(cgroup-limits) ; export $export_vars
 
 source "${CONTAINER_SCRIPTS_PATH}/common.sh"
 

--- a/9.4/root/usr/share/container-scripts/postgresql/openshift-custom-postgresql.conf.template
+++ b/9.4/root/usr/share/container-scripts/postgresql/openshift-custom-postgresql.conf.template
@@ -17,6 +17,9 @@ max_prepared_transactions = ${POSTGRESQL_MAX_CONNECTIONS}
 # Sets the amount of memory the database server uses for shared memory buffers. Default: 32MB
 shared_buffers = ${POSTGRESQL_SHARED_BUFFERS}
 
+# Sets the planner's assumption about the effective size of the disk cache that is available to a single query
+effective_cache_size = ${POSTGRESQL_EFFECTIVE_CACHE_SIZE}
+
 # required on master for replication
 wal_level = hot_standby         # minimal, archive, hot_standby, or logical
 max_wal_senders = 6             # max number of walsender processes


### PR DESCRIPTION
@praiskup @bparees initial database tuning PR.

We already chat about this with @praiskup and his concerns are that we should not be changing the defaults and let users to provide the 'correct' value. 
My thoughts are that we as a platform can deterministically get the memory (based on the resource quota set for the Pod) so we can provide better "default" based on upstream formulas. If we will not do it, users will have to change them every time they  adjust them in OpenShift. The assumption here is that they will follow the upstream formulas and so we can make their life easier by doing that for them. 

Note that this auto-tuning **only** take account when you run the container with `--memory=512MB` or so. By default we don't do anything. Also note that users can still override the values manually (the user  provided env vars take precedence)

@hhorak ptal as well, we might do something similar to mysql :-)

For the reference, there is Trello card for this: https://trello.com/c/cmY00byV/675-8-update-images-to-autoconfigure-based-on-available-memory-template-evg