### PR TITLE
Get limits in run-postgresql-slave as well

### DIFF
--- a/9.4/root/usr/bin/run-postgresql-slave
+++ b/9.4/root/usr/bin/run-postgresql-slave
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -eu
+export_vars=$(cgroup-limits) ; export $export_vars
 
 source "$CONTAINER_SCRIPTS_PATH"/common.sh
 


### PR DESCRIPTION
There is an issue when running run-postgresql-slave with most recent code:

```
#> docker run -ti --rm postgresql-94-rhel7 run-postgresql-slave
/usr/share/container-scripts/postgresql/common.sh: line 8: MEMORY_LIMIT_IN_BYTES: unbound variable
```