### PR TITLE
Disabled setting value max_prepared_transactions. Now it uses default…

### DIFF
--- a/9.2/README.md
+++ b/9.2/README.md
@@ -22,7 +22,8 @@ The following environment variables influence the PostgreSQL configuration file.
 
 |    Variable name              |    Description                                                          |    Default
 | :---------------------------- | ----------------------------------------------------------------------- | -------------------------------
-|  `POSTGRESQL_MAX_CONNECTIONS` | The maximum number of client connections allowed. This also sets the maximum number of prepared transactions. |  100
+|  `POSTGRESQL_MAX_CONNECTIONS` | The maximum number of client connections allowed |  100
+|  `POSTGRESQL_MAX_PREPARED_TRANSACTIONS` | Sets the maximum number of transactions that can be in the "prepared" state. If you are using prepared transactions, you will probably want this to be at least as large as max_connections |  0
 |  `POSTGRESQL_SHARED_BUFFERS`  | Sets how much memory is dedicated to PostgreSQL to use for caching data |  32M
 |  `POSTGRESQL_EFFECTIVE_CACHE_SIZE`  | Set to an estimate of how much memory is available for disk caching by the operating system and within the database itself |  128M
 

--- a/9.2/root/usr/share/container-scripts/postgresql/common.sh
+++ b/9.2/root/usr/share/container-scripts/postgresql/common.sh
@@ -1,5 +1,6 @@
 # Configuration settings.
 export POSTGRESQL_MAX_CONNECTIONS=${POSTGRESQL_MAX_CONNECTIONS:-100}
+export POSTGRESQL_MAX_PREPARED_TRANSACTIONS=${POSTGRESQL_MAX_PREPARED_TRANSACTIONS:-0}
 
 # Perform auto-tuning based on the container cgroups limits (only when the
 # limits are set).
@@ -44,6 +45,7 @@ function usage() {
   echo >&2 "Or both."
   echo >&2 "Optional settings:"
   echo >&2 "  POSTGRESQL_MAX_CONNECTIONS (default: 100)"
+  echo >&2 "  POSTGRESQL_MAX_PREPARED_TRANSACTIONS (default: 0)"
   echo >&2 "  POSTGRESQL_SHARED_BUFFERS (default: 32MB)"
   exit 1
 }

--- a/9.2/root/usr/share/container-scripts/postgresql/openshift-custom-postgresql.conf.template
+++ b/9.2/root/usr/share/container-scripts/postgresql/openshift-custom-postgresql.conf.template
@@ -12,7 +12,7 @@ listen_addresses = '*'
 max_connections = ${POSTGRESQL_MAX_CONNECTIONS}
 
 # Allow each connection to use a prepared transaction
-max_prepared_transactions = ${POSTGRESQL_MAX_CONNECTIONS}
+max_prepared_transactions = ${POSTGRESQL_MAX_PREPARED_TRANSACTIONS}
 
 # Sets the amount of memory the database server uses for shared memory buffers. Default: 32MB
 shared_buffers = ${POSTGRESQL_SHARED_BUFFERS}

--- a/9.2/test/run
+++ b/9.2/test/run
@@ -171,6 +171,7 @@ function run_configuration_tests() {
   local name=$1 ; shift
   echo "  Testing image configuration settings"
   test_config_option ${name} max_connections ${POSTGRESQL_MAX_CONNECTIONS}
+  test_config_option ${name} max_prepared_transactions ${POSTGRESQL_MAX_PREPARED_TRANSACTIONS}
   test_config_option ${name} shared_buffers ${POSTGRESQL_SHARED_BUFFERS}
   echo "  Success!"
 }
@@ -221,6 +222,9 @@ function run_tests() {
   fi
   if [ -v POSTGRESQL_MAX_CONNECTIONS ]; then
     envs="$envs -e POSTGRESQL_MAX_CONNECTIONS=$POSTGRESQL_MAX_CONNECTIONS"
+  fi
+  if [ -v POSTGRESQL_MAX_PREPARED_TRANSACTIONS ]; then
+    envs="$envs -e POSTGRESQL_MAX_PREPARED_TRANSACTIONS=$POSTGRESQL_MAX_PREPARED_TRANSACTIONS"
   fi
   if [ -v POSTGRESQL_SHARED_BUFFERS ]; then
     envs="$envs -e POSTGRESQL_SHARED_BUFFERS=$POSTGRESQL_SHARED_BUFFERS"
@@ -320,12 +324,13 @@ function run_change_password_test() {
 
 # configuration defaults
 POSTGRESQL_MAX_CONNECTIONS=100
+POSTGRESQL_MAX_PREPARED_TRANSACTIONS=0
 POSTGRESQL_SHARED_BUFFERS=32MB
 
 # Tests.
 
 run_container_creation_tests
-PGUSER=user PASS=pass POSTGRESQL_MAX_CONNECTIONS=42 POSTGRESQL_SHARED_BUFFERS=64MB run_tests no_admin
+PGUSER=user PASS=pass POSTGRESQL_MAX_CONNECTIONS=42 POSTGRESQL_MAX_PREPARED_TRANSACTIONS=42 POSTGRESQL_SHARED_BUFFERS=64MB run_tests no_admin
 PGUSER=user1 PASS=pass1 ADMIN_PASS=r00t run_tests admin
 DB=postgres ADMIN_PASS=r00t run_tests only_admin
 # Test with arbitrary uid for the container

--- a/9.4/README.md
+++ b/9.4/README.md
@@ -23,6 +23,7 @@ The following environment variables influence the PostgreSQL configuration file.
 |    Variable name              |    Description                                                          |    Default
 | :---------------------------- | ----------------------------------------------------------------------- | -------------------------------
 |  `POSTGRESQL_MAX_CONNECTIONS` | The maximum number of client connections allowed. This also sets the maximum number of prepared transactions. |  100
+|  `POSTGRESQL_MAX_PREPARED_TRANSACTIONS` | Sets the maximum number of transactions that can be in the "prepared" state. If you are using prepared transactions, you will probably want this to be at least as large as max_connections |  0
 |  `POSTGRESQL_SHARED_BUFFERS`  | Sets how much memory is dedicated to PostgreSQL to use for caching data |  32M
 |  `POSTGRESQL_EFFECTIVE_CACHE_SIZE`  | Set to an estimate of how much memory is available for disk caching by the operating system and within the database itself |  128M
 

--- a/9.4/root/usr/share/container-scripts/postgresql/common.sh
+++ b/9.4/root/usr/share/container-scripts/postgresql/common.sh
@@ -1,5 +1,6 @@
 # Configuration settings.
 export POSTGRESQL_MAX_CONNECTIONS=${POSTGRESQL_MAX_CONNECTIONS:-100}
+export POSTGRESQL_MAX_PREPARED_TRANSACTIONS=${POSTGRESQL_MAX_PREPARED_TRANSACTIONS:-0}
 
 # Perform auto-tuning based on the container cgroups limits (only when the
 # limits are set).
@@ -43,6 +44,7 @@ function usage() {
   echo >&2 "Or both."
   echo >&2 "Optional settings:"
   echo >&2 "  POSTGRESQL_MAX_CONNECTIONS (default: 100)"
+  echo >&2 "  POSTGRESQL_MAX_PREPARED_TRANSACTIONS (default: 0)"
   echo >&2 "  POSTGRESQL_SHARED_BUFFERS (default: 32MB)"
   exit 1
 }

--- a/9.4/root/usr/share/container-scripts/postgresql/openshift-custom-postgresql.conf.template
+++ b/9.4/root/usr/share/container-scripts/postgresql/openshift-custom-postgresql.conf.template
@@ -12,7 +12,7 @@ listen_addresses = '*'
 max_connections = ${POSTGRESQL_MAX_CONNECTIONS}
 
 # Allow each connection to use a prepared transaction
-max_prepared_transactions = ${POSTGRESQL_MAX_CONNECTIONS}
+max_prepared_transactions = ${POSTGRESQL_MAX_PREPARED_TRANSACTIONS}
 
 # Sets the amount of memory the database server uses for shared memory buffers. Default: 32MB
 shared_buffers = ${POSTGRESQL_SHARED_BUFFERS}

--- a/9.4/test/run
+++ b/9.4/test/run
@@ -171,6 +171,7 @@ function run_configuration_tests() {
   local name=$1 ; shift
   echo "  Testing image configuration settings"
   test_config_option ${name} max_connections ${POSTGRESQL_MAX_CONNECTIONS}
+  test_config_option ${name} max_prepared_transactions ${POSTGRESQL_MAX_PREPARED_TRANSACTIONS}
   test_config_option ${name} shared_buffers ${POSTGRESQL_SHARED_BUFFERS}
   echo "  Success!"
 }
@@ -221,6 +222,9 @@ function run_tests() {
   fi
   if [ -v POSTGRESQL_MAX_CONNECTIONS ]; then
     envs="$envs -e POSTGRESQL_MAX_CONNECTIONS=$POSTGRESQL_MAX_CONNECTIONS"
+  fi
+  if [ -v POSTGRESQL_MAX_PREPARED_TRANSACTIONS ]; then
+    envs="$envs -e POSTGRESQL_MAX_PREPARED_TRANSACTIONS=$POSTGRESQL_MAX_PREPARED_TRANSACTIONS"
   fi
   if [ -v POSTGRESQL_SHARED_BUFFERS ]; then
     envs="$envs -e POSTGRESQL_SHARED_BUFFERS=$POSTGRESQL_SHARED_BUFFERS"
@@ -320,12 +324,13 @@ function run_change_password_test() {
 
 # configuration defaults
 POSTGRESQL_MAX_CONNECTIONS=100
+POSTGRESQL_MAX_PREPARED_TRANSACTIONS=0
 POSTGRESQL_SHARED_BUFFERS=32MB
 
 # Tests.
 
 run_container_creation_tests
-PGUSER=user PASS=pass POSTGRESQL_MAX_CONNECTIONS=42 POSTGRESQL_SHARED_BUFFERS=64MB run_tests no_admin
+PGUSER=user PASS=pass POSTGRESQL_MAX_CONNECTIONS=42 POSTGRESQL_MAX_PREPARED_TRANSACTIONS=42 POSTGRESQL_SHARED_BUFFERS=64MB run_tests no_admin
 PGUSER=user1 PASS=pass1 ADMIN_PASS=r00t run_tests admin
 DB=postgres ADMIN_PASS=r00t run_tests only_admin
 # Test with arbitrary uid for the container


### PR DESCRIPTION
… value which is 0. This PR is based on ticket #65 