### PR TITLE
set cgroup limit env variables in slave script

### DIFF
--- a/9.2/root/usr/bin/run-postgresql-slave
+++ b/9.2/root/usr/bin/run-postgresql-slave
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -eu
+export_vars=$(cgroup-limits) ; export $export_vars
 
 source "$CONTAINER_SCRIPTS_PATH"/common.sh
 


### PR DESCRIPTION
should fix https://github.com/openshift/origin/issues/9188

@gabemontero 